### PR TITLE
fix(kube-scheduler): add arg for --leader-elect-resource-namespace

### DIFF
--- a/charts/kube-scheduler/Chart.yaml
+++ b/charts/kube-scheduler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kube-scheduler
 description: A Helm chart for Kubernetes scheduler
-version: 0.2.1
+version: 0.2.2
 keywords:
   - k8s
   - kubernetes

--- a/charts/kube-scheduler/README.md
+++ b/charts/kube-scheduler/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for Kubernetes scheduler
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square)
 
 ## About
 Kube-Scheduler Helm chart

--- a/charts/kube-scheduler/templates/deployment.yaml
+++ b/charts/kube-scheduler/templates/deployment.yaml
@@ -49,6 +49,7 @@ spec:
           - /usr/local/bin/kube-scheduler
           - "--leader-elect={{ if gt (int .Values.replicaCount) 1 }}true{{ else }}false{{ end }}"
           - "--leader-elect-resource-name={{ include "kube-scheduler.leaderElectResourceName" . }}"
+          - "--leader-elect-resource-namespace={{ .Release.Namespace }}"
           - "--config=/etc/kubernetes/scheduler-config.yaml"
           - "--authentication-skip-lookup=true"
           - "-v={{ int .Values.logLevel }}"

--- a/charts/kube-scheduler/templates/rbac.yaml
+++ b/charts/kube-scheduler/templates/rbac.yaml
@@ -124,6 +124,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leasecandidates


### PR DESCRIPTION
# Description
## Leader Elect Namespace
Adding argument to kube-scheduler to set: `  - "--leader-elect-resource-namespace={{ .Release.Namespace }}"`

This will automatically set the resource namespace for leaderElection and lock based on current namespace setting received to input. For example from ArgoCD.

More about this argument is written here: 
https://kubernetes.io/docs/reference/command-line-tools-reference/kube-scheduler/
https://kubernetes.io/docs/reference/config-api/kube-scheduler-config.v1/#LeaderElectionConfiguration

## Missing RBAC policy for service account
We see error in logs:
```
User \"system:serviceaccount:kube-system:kube-scheduler\" cannot list resources \"volumeattachments\" in API group \"storage.k8s.io\" at the cluster scope
```

## Type of change

- [x] A bug fix (PR prefix `fix`)
- [ ] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?
In local lab, dev edge

Post deployment we got expected outcome and all is running fine:
```
│   - command:                                                                                                                                                                             
│     - /usr/local/bin/kube-scheduler                                                                                                                                                      
│     - --leader-elect=true                                                                                                                                                                
│     - --leader-elect-resource-name=kube-scheduler-leader-election                                                                                                                        
│     - --leader-elect-resource-namespace=kube-system                                                                                                                                      
│     - --config=/etc/kubernetes/scheduler-config.yaml                                                                                                                                     
│     - --authentication-skip-lookup=true      
```
